### PR TITLE
libco: Use __declspec(thread) on MSVC

### DIFF
--- a/amd64.c
+++ b/amd64.c
@@ -15,6 +15,10 @@
 extern "C" {
 #endif
 
+#ifdef _MSC_VER
+#define thread_local __declspec (thread)
+#endif
+
 static thread_local long long co_active_buffer[64];
 static thread_local cothread_t co_active_handle = 0;
 static void (*co_swap)(cothread_t, cothread_t) = 0;

--- a/x86.c
+++ b/x86.c
@@ -23,6 +23,10 @@ extern "C" {
   #error "libco: please define fastcall macro"
 #endif
 
+#ifdef _MSC_VER
+#define thread_local __declspec (thread)
+#endif
+
 static thread_local long co_active_buffer[64];
 static thread_local cothread_t co_active_handle = 0;
 static void (fastcall *co_swap)(cothread_t, cothread_t) = 0;


### PR DESCRIPTION
To build with MSVC, we should use __declspec(thread) instead of
thread_local attribute for type.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>