### PR TITLE
Suppress thread_local macro redefined warnings

### DIFF
--- a/amd64.c
+++ b/amd64.c
@@ -15,10 +15,6 @@
 extern "C" {
 #endif
 
-#ifdef _MSC_VER
-#define thread_local __declspec (thread)
-#endif
-
 static thread_local long long co_active_buffer[64];
 static thread_local cothread_t co_active_handle = 0;
 static void (*co_swap)(cothread_t, cothread_t) = 0;

--- a/settings.h
+++ b/settings.h
@@ -19,7 +19,11 @@
 
 #ifdef LIBCO_C
   #ifdef LIBCO_MP
-    #define thread_local __thread
+    #ifdef _MSC_VER
+      #define thread_local __declspec (thread)
+    #else
+      #define thread_local __thread
+    #endif
   #else
     #define thread_local
   #endif

--- a/x86.c
+++ b/x86.c
@@ -23,10 +23,6 @@ extern "C" {
   #error "libco: please define fastcall macro"
 #endif
 
-#ifdef _MSC_VER
-#define thread_local __declspec (thread)
-#endif
-
 static thread_local long co_active_buffer[64];
 static thread_local cothread_t co_active_handle = 0;
 static void (fastcall *co_swap)(cothread_t, cothread_t) = 0;


### PR DESCRIPTION
Previous first aid patch generates `thread_local` macro redefiend warnings.
This patch fixes it.

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>