### PR TITLE
aarch64: fix segmentation fault on co_switch()

### DIFF
--- a/aarch64.c
+++ b/aarch64.c
@@ -20,9 +20,6 @@
 extern "C" {
 #endif
 
-static thread_local uint64_t co_active_buffer[64];
-static thread_local cothread_t co_active_handle;
-
 asm (
       ".globl co_switch_aarch64\n"
       ".globl _co_switch_aarch64\n"
@@ -58,6 +55,16 @@ asm (
 
 /* ASM */
 void co_switch_aarch64(cothread_t handle, cothread_t current);
+
+/*
+ * NOTE! We defer to define thread locals here because GCC v7.4
+ * has a bug that over-applies ".tbss" section.
+ *
+ * Due to the bug, it would cause SIGSEGV if we place these lines
+ * before asm(). So beware when moving code around.
+ */
+static thread_local uint64_t co_active_buffer[64];
+static thread_local cothread_t co_active_handle;
 
 static void crash(void)
 {


### PR DESCRIPTION
GCC has a bug that over-applies ".tbss" section, which causes the
subsequent asm() call to be stored in TLS wrongly. This was the
root cause of libco crashing with SIGSEGV on ARMv8.

This is a straight-forward workaround for the bug, and should make
libco work fine on ARMv8.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>