### PR TITLE
ucontext: make sure to include settings.h

### DIFF
--- a/ucontext.c
+++ b/ucontext.c
@@ -18,6 +18,7 @@
 
 #define LIBCO_C
 #include "libco.h"
+#include "settings.h"
 
 #define _BSD_SOURCE
 #include <stdlib.h>


### PR DESCRIPTION
Right now, gcc fails to compile ucontext.c with an error "unknown
type name thread_local" as follows.

    $ make
    ...
    ucontext.c:30:8: error: unknown type name ‘thread_local’

... which is just because ucontext.c forgot to include settings.h
that defines the macro for the keyword. Fix it.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>