### PR TITLE
core: use fiber backend instead of libco on Win64 build

### DIFF
--- a/fiber.c
+++ b/fiber.c
@@ -6,6 +6,7 @@
 
 #define LIBCO_C
 #include "libco.h"
+#include "settings.h"
 
 #define WINVER 0x0400
 #define _WIN32_WINNT 0x0400

--- a/libco.c
+++ b/libco.c
@@ -26,8 +26,9 @@
 #elif defined(_MSC_VER)
   #if defined(_M_IX86)
     #include "x86.c"
-  #elif defined(_M_AMD64)
-    #include "amd64.c"
+// Commented out due to SIGSEGV bug
+//  #elif defined(_M_AMD64)
+//    #include "amd64.c"
   #else
     #include "fiber.c"
   #endif


### PR DESCRIPTION
This is a quick fix for the segementation fault bug I see occurring
on Win64 build.

    PS> .\bin\fluent-bit.exe
    ...
    [trace] [thread] destroy thread=00000297AB9BCD10 data=00000297AB9BCD30
    SIGSEGV

The root cause is not fully figured out yet, but it is very likely
that there is some Windows-specific memory management bug in arm64.c

I'll investigate the bug more later; Until any fix is found, we
need this in order to make fluent-bit work fine on Win64.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>