### PR TITLE
aarch64: fix malloc header on FreeBSD

### DIFF
--- a/aarch64.c
+++ b/aarch64.c
@@ -12,8 +12,12 @@
 #include <string.h>
 #include <stdint.h>
 
-#ifndef IOS
-#include <malloc.h>
+#if defined(IOS)
+#elif defined(__FreeBSD__)
+#include <malloc_np.h>
+#define HAVE_POSIX_MEMALIGN 1
+#else                                
+#include <malloc.h>     
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
It's actually weird that there's a check for `HAVE_POSIX_MEMALIGN` but it's not set by CMake… anyway, this is the minimal change to fix compilation