### PR TITLE
Fix problem with SIGSEGV on FreeBSD 12+

### DIFF
--- a/settings.h
+++ b/settings.h
@@ -42,6 +42,8 @@
   #define text_section __declspec(allocate(".text"))
 #elif defined(__APPLE__) && defined(__MACH__)
   #define text_section __attribute__((section("__TEXT,__text")))
+#elif defined(__clang__)
+  #define text_section __attribute__((section(".text")))
 #else
   #define text_section __attribute__((section(".text#")))
 #endif


### PR DESCRIPTION
The issue is a SIGSEGV that is caused by incorrect section structure of the
resulting binary file generated by clang due to some gcc specific code in
libco.

This patch was tested on FreeBSD 11.4 and 12.2 amd64.  The resulting binaries
was tested with "elfdump -a" to contain only one ".text" section and their
startup logs were tested running "fluent-bit -v -i dummy -o stdout".

See also: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=250825
Submitted by: Yuri Pankov and Artyom Davidov
Signed-off-by: Palle Girgensohn <girgen@FreeBSD.org>