### PR TITLE
Add support for building on Apple Silicon/M1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,5 +2,13 @@ set(src
   libco.c
   )
 
+# Check for posix_memalign so that Apple Silicon can be supported
+include(CheckSymbolExists)
+check_symbol_exists(posix_memalign "stdlib.h" HAVE_POSIX_MEMALIGN)
+IF(HAVE_POSIX_MEMALIGN)
+  add_definitions(-DHAVE_POSIX_MEMALIGN)
+  MESSAGE("Found posix_memalign setting -DHAVE_POSIX_MEMALIGN")
+ENDIF(HAVE_POSIX_MEMALIGN)
+
 add_definitions(-DLIBCO_MP)
 add_library(co STATIC ${src})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,14 @@ set(src
   libco.c
   )
 
-# Check for posix_memalign so that Apple Silicon can be supported
 include(CheckSymbolExists)
+
+# Check for posix_memalign so that Apple Silicon can be supported
 check_symbol_exists(posix_memalign "stdlib.h" HAVE_POSIX_MEMALIGN)
+
+# Check for posix_memalign so that FreeBSD can be supported
+check_symbol_exists(posix_memalign "malloc_np.h" HAVE_POSIX_MEMALIGN)
+
 IF(HAVE_POSIX_MEMALIGN)
   add_definitions(-DHAVE_POSIX_MEMALIGN)
   MESSAGE("Found posix_memalign setting -DHAVE_POSIX_MEMALIGN")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,15 +5,24 @@ set(src
 include(CheckSymbolExists)
 
 # Check for posix_memalign so that Apple Silicon can be supported
-check_symbol_exists(posix_memalign "stdlib.h" HAVE_POSIX_MEMALIGN)
+check_symbol_exists(posix_memalign "stdlib.h" HAVE_POSIX_MEMALIGN_IN_STDLIB)
+
+IF(HAVE_POSIX_MEMALIGN_IN_STDLIB)
+  # We need HAVE_POSIX_MEMALIGN for the ifdefs to use posix_memalign
+  # We defined HAVE_POSIX_MEMALIGN_IN_STDLIB in order to avoid including in malloc.h
+  add_definitions(-DHAVE_POSIX_MEMALIGN_IN_STDLIB -DHAVE_POSIX_MEMALIGN)
+  MESSAGE("Found posix_memalign in stdlib.h -DHAVE_POSIX_MEMALIGN_IN_STDLIB -DHAVE_POSIX_MEMALIGN")
+ENDIF(HAVE_POSIX_MEMALIGN_IN_STDLIB)
 
 # Check for posix_memalign so that FreeBSD can be supported
-check_symbol_exists(posix_memalign "malloc_np.h" HAVE_POSIX_MEMALIGN)
+check_symbol_exists(posix_memalign "malloc_np.h" HAVE_POSIX_MEMALIGN_IN_PTHREAD_NP)
 
-IF(HAVE_POSIX_MEMALIGN)
-  add_definitions(-DHAVE_POSIX_MEMALIGN)
-  MESSAGE("Found posix_memalign setting -DHAVE_POSIX_MEMALIGN")
-ENDIF(HAVE_POSIX_MEMALIGN)
+IF(HAVE_POSIX_MEMALIGN_IN_PTHREAD_NP)
+  # We need HAVE_POSIX_MEMALIGN for the ifdefs to use posix_memalign
+  # We defined DHAVE_POSIX_MEMALIGN_IN_PTHREAD_NP in order to include malloc_np.h
+  add_definitions(-DHAVE_POSIX_MEMALIGN_IN_PTHREAD_NP -DHAVE_POSIX_MEMALIGN)
+  MESSAGE("Found posix_memalign in malloc_np.h -DHAVE_POSIX_MEMALIGN_IN_PTHREAD_NP -DHAVE_POSIX_MEMALIGN")
+ENDIF(HAVE_POSIX_MEMALIGN_IN_PTHREAD_NP)
 
 add_definitions(-DLIBCO_MP)
 add_library(co STATIC ${src})

--- a/aarch64.c
+++ b/aarch64.c
@@ -12,8 +12,10 @@
 #include <string.h>
 #include <stdint.h>
 
+#ifndef __APPLE__
 #ifndef IOS
 #include <malloc.h>
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/aarch64.c
+++ b/aarch64.c
@@ -12,10 +12,11 @@
 #include <string.h>
 #include <stdint.h>
 
-#ifndef __APPLE__
-#ifndef IOS
+#if defined(__APPLE__)
+#elif defined(__FreeBSD__)
+#include <malloc_np.h>
+#else
 #include <malloc.h>
-#endif
 #endif
 
 #ifdef __cplusplus

--- a/aarch64.c
+++ b/aarch64.c
@@ -12,8 +12,9 @@
 #include <string.h>
 #include <stdint.h>
 
-#if defined(__APPLE__)
-#elif defined(__FreeBSD__)
+#if defined(HAVE_POSIX_MEMALIGN_IN_STDLIB)
+/* stdlib is already included */
+#elif defined(HAVE_POSIX_MEMALIGN_IN_PTHREAD_NP)
 #include <malloc_np.h>
 #else
 #include <malloc.h>


### PR DESCRIPTION
Don't #include <malloc.h> if __APPLE__ is defined
Detect posix_memalign in CMake